### PR TITLE
Use PrintTo instead of PrintTo1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 This file describes changes in the GAP package 'liealgdb'.
 
+* unreleased
+
+  - Fix printing of Lie algebra collections in a GAP where GAPDoc is not
+    loaded (e.g. one started with `gap --bare`)
+
 * 2.3.0 (2025-09-24)
 
   - Fix incorrect ordering for `N6_26`, `N6_27`; that is, the order

--- a/gap/liealgdb.gi
+++ b/gap/liealgdb.gi
@@ -1,15 +1,11 @@
-# String( F ) does not work for a field in gap -A. Here is a fix.
-#
-# this is taken from gapdoc and put here to avoid future incompatibility
+# String( F ) does not work for a field, and PrintString( F ) gives
+# "Magma( ... )", so capture what Print( F ) produces.
 
 BindGlobal( "LieAlgDBField2String", function ( F )
     local  str, out;
     str := "";
     out := OutputTextString( str, false );
-    PrintTo1( out, function (  )
-          Print( F );
-          return;
-      end );
+    PrintTo( out, F );
     CloseStream( out );
     return str;
 end );


### PR DESCRIPTION
LieAlgDBField2String captures the output of Print( F ) in a string, using
PrintTo1. That function comes from the GAPDoc package, which LieAlgDB
does not declare as a dependency, so printing a collection failed in a
GAP where GAPDoc is not loaded, e.g. one started with `gap --bare':

    Error, Variable: 'PrintTo1' must have an assigned value

PrintTo of the GAP library also accepts an output stream and gives the
same result here, so use that. Note that PrintString is not an
alternative: for a field it returns "Magma( ... )".

The comment claiming the code was taken from GAPDoc to avoid future
incompatibility is dropped, since it now uses no GAPDoc function at all.

See https://github.com/gap-system/gap/issues/2434

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
